### PR TITLE
Prevent 2 instances of shared Facebook shared window

### DIFF
--- a/bsp-share.js
+++ b/bsp-share.js
@@ -169,7 +169,9 @@ var module = {
                             'link='         + url           + '&' +
                             'caption='      + caption       + '&' +
                             'description='  + description   + '&' +
-                            'redirect_uri=' + redirectUrl   + '&' +
+                            // this prevents facebook's popup from also showing the shared page
+                            // and staying open w/ that 2nd instance ...
+                            // 'redirect_uri=' + redirectUrl   + '&' +
                             'picture='      + image;
                 break;
 


### PR DESCRIPTION
... if a redirect_uri is passed to Facebook, the popup redirects to that URI and stays open
... this update removes that param (link param is still used for actual share)